### PR TITLE
Update Paizo; Playtest.json

### DIFF
--- a/collection/Paizo; Playtest.json
+++ b/collection/Paizo; Playtest.json
@@ -755,6 +755,7 @@
 								"Subclass Dependant"
 							],
 							"entry": "one or more skills determined by your way."
+						}							
 					],
 					"add": 3
 				},

--- a/collection/Paizo; Playtest.json
+++ b/collection/Paizo; Playtest.json
@@ -750,7 +750,11 @@
 				"skills": {
 					"t": [
 						"Crafting",
-						"one or more skills determined by your way."
+						{
+							"skill": [
+								"Subclass Dependant"
+							],
+							"entry": "one or more skills determined by your way."
 					],
 					"add": 3
 				},
@@ -1369,7 +1373,12 @@
 				"will": "E",
 				"skills": {
 					"t": [
-						"one or more skills determined by your eidolon"
+						{
+							"skill": [
+								"Subclass Dependant"
+							],
+							"entry": "one or more skills determined by your eidolon"
+						}
 					],
 					"add": 3
 				},

--- a/collection/Paizo; Playtest.json
+++ b/collection/Paizo; Playtest.json
@@ -330,10 +330,10 @@
 				"will": "E",
 				"skills": {
 					"t": [
-						"{@skill Arcana}",
-						"{@skill Nature}",
-						"{@skill Occultism}",
-						"{@skill Religion}"
+						"Arcana",
+						"Nature",
+						"Occultism",
+						"Religion"
 					],
 					"add": 2
 				},
@@ -544,7 +544,7 @@
 				"will": "E",
 				"skills": {
 					"t": [
-						"{@skill Occultism}"
+						"Occultism"
 					],
 					"add": 3
 				},
@@ -749,7 +749,7 @@
 				"will": "T",
 				"skills": {
 					"t": [
-						"{@skill Crafting}",
+						"Crafting",
 						"one or more skills determined by your way."
 					],
 					"add": 3
@@ -959,7 +959,7 @@
 				"will": "E",
 				"skills": {
 					"t": [
-						"{@skill Crafting}"
+						"Crafting"
 					],
 					"add": 3
 				},
@@ -1169,7 +1169,7 @@
 				"will": "E",
 				"skills": {
 					"t": [
-						"{@skill Arcana}"
+						"Arcana"
 					],
 					"add": 2
 				},


### PR DESCRIPTION
Skills were showing up in class filter as raw text (eg. as {@skill Crafting} rather than just Crafting). This should fix it.